### PR TITLE
Fix pkgconf environment variables

### DIFF
--- a/stela.sh
+++ b/stela.sh
@@ -119,7 +119,7 @@ export MAKEFLAGS="-j$NUM_JOBS"
 export BUILDFLAGS="--build=$XHOST --host=$XTARGET"
 export TOOLFLAGS="--build=$XHOST --host=$XTARGET --target=$XTARGET"
 export PERLFLAGS="--target=$XTARGET"
-export PKG_CONFIG_PATH="$FIN_DIR/usr/lib/pkgconfig:$FIN_DIR/usr/share/pkgconfig"
+export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
 export PKG_CONFIG_SYSROOT="$FIN_DIR"
 
 # ----- Path ----- #


### PR DESCRIPTION
According to `pkgconf`'s man page:
```
PKG_CONFIG_SYSROOT_DIR
‘sysroot’ directory, will be prepended to every path defined in PKG_CONFIG_PATH. Useful for cross compilation.
```